### PR TITLE
Adds a .packit file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bin
 rust-dist-cnb_*
+build

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,6 @@ api = "0.4"
 [buildpack]
   id = "paketo-community/rust-dist"
   name = "Rust Distribution Buildpack"
-  version = "0.0.8"
   homepage = "https://github.com/paketo-community/rust-dist"
 
 [[stacks]]
@@ -16,8 +15,8 @@ api = "0.4"
   id = "org.cloudfoundry.stacks.cflinuxfs3"
 
 [metadata]
-  include_files = ["bin/build", "bin/detect", "buildpack.toml"]
-  pre_package = "./scripts/build.sh"
+  include-files = ["bin/build", "bin/detect", "buildpack.toml"]
+  pre-package = "./scripts/build.sh"
 
   # from https://forge.rust-lang.org/infra/other-installation-methods.html#standalone
   [[metadata.dependencies]]


### PR DESCRIPTION
- This file indicates to the automation which packager should be used.
This will mean that the buildpack will now be built with jam and receive
the proper formatting. Previously the version inside of buildpack.toml
was not being overwritten.