### PR TITLE
Set CARGO_HOME

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/buildpacks/libcnb v1.22.0
+	github.com/heroku/color v0.0.6
 	github.com/onsi/gomega v1.16.0
 	github.com/paketo-buildpacks/libpak v1.53.0
 	github.com/sclevine/spec v1.4.0

--- a/rust/build_test.go
+++ b/rust/build_test.go
@@ -49,8 +49,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		result, err := rust.Build{}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(result.Layers).To(HaveLen(1))
-		Expect(result.Layers[0].Name()).To(Equal("rust"))
+		Expect(result.Layers).To(HaveLen(2))
+		Expect(result.Layers[0].Name()).To(Equal("Cargo"))
+		Expect(result.Layers[1].Name()).To(Equal("rust"))
 
 		Expect(result.BOM.Entries).To(HaveLen(1))
 		Expect(result.BOM.Entries[0].Name).To(Equal("rust"))
@@ -90,7 +91,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			result, err := rust.Build{}.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(result.Layers[0].(rust.Rust).LayerContributor.Dependency.Version).To(Equal("1.1.1"))
+			Expect(result.Layers[1].(rust.Rust).LayerContributor.Dependency.Version).To(Equal("1.1.1"))
 		})
 	})
 }

--- a/rust/cargo.go
+++ b/rust/cargo.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rust
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/buildpacks/libcnb"
+	"github.com/heroku/color"
+	"github.com/paketo-buildpacks/libpak/bard"
+)
+
+type Cargo struct {
+	Logger bard.Logger
+}
+
+func (c Cargo) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
+	c.Logger.Headerf("%s: %s to layer", color.BlueString(c.Name()), color.YellowString("Contributing"))
+
+	AppendToPath(filepath.Join(layer.Path, "bin"))
+
+	if err := os.Setenv("CARGO_HOME", layer.Path); err != nil {
+		return libcnb.Layer{}, fmt.Errorf("unable to set $CARGO_HOME\n%w", err)
+	}
+
+	layer.BuildEnvironment.Override("CARGO_HOME", layer.Path)
+	layer.LayerTypes = libcnb.LayerTypes{
+		Build: true,
+		Cache: true,
+	}
+
+	return layer, nil
+}
+
+func (c Cargo) Name() string {
+	return "Cargo"
+}

--- a/rust/cargo_test.go
+++ b/rust/cargo_test.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rust_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/buildpacks/libcnb"
+	. "github.com/onsi/gomega"
+	"github.com/paketo-community/rust-dist/rust"
+	"github.com/sclevine/spec"
+)
+
+func testCargo(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		ctx libcnb.BuildContext
+	)
+
+	it.Before(func() {
+		var err error
+
+		ctx.Layers.Path, err = ioutil.TempDir("", "cargo-layers")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(ctx.Layers.Path)).To(Succeed())
+	})
+
+	it("contributes cargo layer", func() {
+		c := rust.Cargo{}
+
+		layer, err := ctx.Layers.Layer("test-layer")
+		Expect(err).NotTo(HaveOccurred())
+
+		layer, err = c.Contribute(layer)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(layer.LayerTypes.Build).To(BeTrue())
+		Expect(layer.LayerTypes.Cache).To(BeTrue())
+		Expect(layer.LayerTypes.Launch).To(BeFalse())
+
+		Expect(os.Getenv("PATH")).To(HaveSuffix(fmt.Sprintf(":%s/bin", layer.Path)))
+		Expect(os.Getenv("CARGO_HOME")).To(Equal(layer.Path))
+		Expect(layer.BuildEnvironment).To(HaveKeyWithValue("CARGO_HOME.override", layer.Path))
+	})
+}

--- a/rust/init_test.go
+++ b/rust/init_test.go
@@ -10,6 +10,7 @@ import (
 func TestUnitRust(t *testing.T) {
 	suite := spec.New("rust", spec.Report(report.Terminal{}))
 	suite("Build", testBuild)
+	suite("Cargo", testCargo)
 	suite("Detect", testDetect)
 	suite("Rust", testRust)
 	suite.Run(t)


### PR DESCRIPTION
This PR ensures that a layer for CARGO_HOME is created and that the CARGO_HOME env variable is set at build time.

This enables tools to locate CARGO_HOME automatically, since CARGO_HOME is a well-known env variables used by Rust tools.