### PR TITLE
Adds dependency to pipeline descriptor for updating the dependency

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -15,3 +15,9 @@ docker_credentials:
   - registry: docker.io
     username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
     password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
+
+dependencies:
+- id:   rust
+  uses: docker://ghcr.io/paketo-buildpacks/actions/paketo-deps-dependency:main
+  with:
+    name: rust


### PR DESCRIPTION
This will enable the bot to submit PRs to update the buildpack when new versions of `rust` are released. It looks at the Paketo Deps server and uses the API to pull the most recent versions from there.