### PR TITLE
Removes second entry in buildpack.toml, which isn't supported with the CI update process

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -45,29 +45,11 @@ build = true
 id = "rust"
 name = "Rust"
 version = "1.55.0"
-sha256 = "8c32495663607d41d7f650c674a013b4cb59b84dbdcb94052581efb95e95cbb6"
 uri = "https://deps.paketo.io/rust/rust_1.55.0_linux_noarch_bionic_8c324956.tgz"
+sha256 = "8c32495663607d41d7f650c674a013b4cb59b84dbdcb94052581efb95e95cbb6"
 stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
 source = "https://static.rust-lang.org/dist/rustc-1.55.0-src.tar.gz"
 source_sha256 = "b2379ac710f5f876ee3c3e03122fe33098d6765d371cac6c31b1b6fc8e43821e"
-
-[[metadata.dependencies.licenses]]
-type = "Apache-2.0"
-uri  = "https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE"
-
-[[metadata.dependencies.licenses]]
-type = "MIT"
-uri  = "https://github.com/rust-lang/rust/blob/master/LICENSE-MIT"
-
-[[metadata.dependencies]]
-id = "rust"
-name = "Rust"
-version = "1.54.0"
-sha256 = "63847be67cfa9f468279b6750d2a31beb6faf19c2eb1cdd6e0c9bc20b8ef0b54"
-uri = "https://deps.paketo.io/rust/rust_1.54.0_linux_noarch_bionic_63847be6.tgz"
-stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
-source = "https://static.rust-lang.org/dist/rustc-1.54.0-src.tar.gz"
-source_sha256 = "ac8511633e9b5a65ad030a1a2e5bdaa841fdfe3132f2baaa52cc04e71c6c6976"
 
 [[metadata.dependencies.licenses]]
 type = "Apache-2.0"


### PR DESCRIPTION
This should fix this update failure:

https://github.com/paketo-community/rust-dist/runs/3691774334?check_suite_focus=true

There were a couple issues:

1. The update mechanism is fragile and depends on the entries being in a specific order. I had to move the sha256 hash below the uri.
2. The update mechanism doesn't support two versions of a dependency. I removed the older version. This isn't a major issue as you can control the version of the buildpack used if you need to pick an older version of Rust. If at some point, Rust has a 2.x release, we could continue to retain 1.x and 2.x, but it can't do N and N-1 versions.