### PR TITLE
Mark BOM entry as Launch

### DIFF
--- a/rust/build_test.go
+++ b/rust/build_test.go
@@ -55,7 +55,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(result.BOM.Entries).To(HaveLen(1))
 		Expect(result.BOM.Entries[0].Name).To(Equal("rust"))
-		Expect(result.BOM.Entries[0].Launch).To(BeFalse())
+		Expect(result.BOM.Entries[0].Launch).To(BeTrue())
 		Expect(result.BOM.Entries[0].Build).To(BeTrue())
 	})
 

--- a/rust/rust.go
+++ b/rust/rust.go
@@ -27,8 +27,10 @@ func NewRust(dependency libpak.BuildpackDependency, cache libpak.DependencyCache
 		})
 	contributor.ExpectedMetadata = expected
 
-	// Rust is a build-time only dependency, but it statically compiles binaries so it
-	//  should be included in the launch time BOM so you know what version of Rust compiled the binaries
+	// This is a workaround. At the moment, there is no feasible way with pack to see the build BOM, you can only see
+    //   the launch BOM. We are including this dependency in the launch BOM for now to workaround this limitation.
+    // When https://github.com/buildpacks/pack/issues/1221 is resolved and one can easily access report.toml
+    //   we should remove this workaround.
 	be.Launch = true
 
 	return Rust{

--- a/rust/rust.go
+++ b/rust/rust.go
@@ -27,6 +27,10 @@ func NewRust(dependency libpak.BuildpackDependency, cache libpak.DependencyCache
 		})
 	contributor.ExpectedMetadata = expected
 
+	// Rust is a build-time only dependency, but it statically compiles binaries so it
+	//  should be included in the launch time BOM so you know what version of Rust compiled the binaries
+	be.Launch = true
+
 	return Rust{
 		LayerContributor: contributor,
 	}, be


### PR DESCRIPTION
While Rust is not a launch dependency, it's version is important to know because it statically compiles binaries. Thus we are going to include its dependency into the launch BOM. This also works around an issue with buildpacks where the build BOM is not really visible. It's not included in `pack inspect` and the BOM label on the image.

Resolves #26 
