### PR TITLE
Add SBOM Support

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 the original author or authors.
+# Copyright 2018-2022 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api = "0.6"
+api = "0.7"
 
 [buildpack]
   description = "A Cloud Native Buildpack that provides the Rust language build tools."
@@ -20,6 +20,7 @@ api = "0.6"
   id = "paketo-community/rust-dist"
   keywords = ["rust", "rustc", "cargo", "tools"]
   name = "Rust Distribution Buildpack"
+  sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 
   [[buildpack.licenses]]
@@ -37,10 +38,12 @@ api = "0.6"
     name = "BP_RUST_VERSION"
 
   [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:rust:rust:1.60.0:*:*:*:*:*:*:*"]
     id = "rust"
     name = "Rust"
+    purl = "pkg:generic/rust@1.60.0"
     sha256 = "4ad9ffac67e467658b7eca7ebffa0c8b7ad3b9702dca0efd6c228914da9bb3da"
-    source = "https://static.rust-lang.org/dist/rustc-1.55.0-src.tar.gz"
+    source = "https://static.rust-lang.org/dist/rustc-1.60.0-src.tar.gz"
     source_sha256 = "b2379ac710f5f876ee3c3e03122fe33098d6765d371cac6c31b1b6fc8e43821e"
     stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
     uri = "https://deps.paketo.io/rust/rust_1.60.0_linux_noarch_bionic_4ad9ffac.tgz"

--- a/rust/build.go
+++ b/rust/build.go
@@ -52,11 +52,9 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.BuildResult{}, fmt.Errorf("unable to find dependency\n%w", err)
 		}
 
-		rust, be := NewRust(rustDependency, dc)
+		rust := NewRust(rustDependency, dc)
 		rust.Logger = b.Logger
-
 		result.Layers = append(result.Layers, rust)
-		result.BOM.Entries = append(result.BOM.Entries, be)
 	}
 
 	return result, nil

--- a/rust/build_test.go
+++ b/rust/build_test.go
@@ -52,11 +52,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(result.Layers).To(HaveLen(2))
 		Expect(result.Layers[0].Name()).To(Equal("Cargo"))
 		Expect(result.Layers[1].Name()).To(Equal("rust"))
-
-		Expect(result.BOM.Entries).To(HaveLen(1))
-		Expect(result.BOM.Entries[0].Name).To(Equal("rust"))
-		Expect(result.BOM.Entries[0].Launch).To(BeTrue())
-		Expect(result.BOM.Entries[0].Build).To(BeTrue())
 	})
 
 	context("$BP_RUST_VERSION", func() {

--- a/rust/rust_test.go
+++ b/rust/rust_test.go
@@ -39,7 +39,7 @@ func testRust(t *testing.T, context spec.G, it spec.S) {
 		}
 		dc := libpak.DependencyCache{CachePath: "testdata"}
 
-		j, _ := rust.NewRust(dep, dc)
+		j := rust.NewRust(dep, dc)
 		j.Logger = bard.NewLogger(ioutil.Discard)
 
 		layer, err := ctx.Layers.Layer("test-layer")
@@ -51,6 +51,8 @@ func testRust(t *testing.T, context spec.G, it spec.S) {
 		Expect(layer.LayerTypes.Launch).To(BeFalse())
 		Expect(layer.LayerTypes.Build).To(BeTrue())
 		Expect(layer.LayerTypes.Cache).To(BeTrue())
+
 		Expect(filepath.Join(layer.Path, "fixture-marker")).To(BeARegularFile())
+		Expect(layer.SBOMPath(libcnb.SyftJSON)).To(BeARegularFile())
 	})
 }


### PR DESCRIPTION
Adds SBOM support for installed dependencies: rust. Support is added for Syft JSON format.

This PR generates the Syft JSON through libpak, which automatically adds it for a given dependency layer contributor.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>