### PR TITLE
Revert "Bump rust from 1.72.0 to 1.71.1"

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -38,16 +38,16 @@ api = "0.7"
     name = "BP_RUST_VERSION"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:rust:rust:1.71.1:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:rust:rust:1.72.0:*:*:*:*:*:*:*"]
     id = "rust"
     name = "Rust"
-    purl = "pkg:generic/rust@1.71.1"
-    sha256 = "34778d1cda674990dfc0537bc600066046ae9cb5d65a07809f7e7da31d4689c4"
+    purl = "pkg:generic/rust@1.72.0"
+    sha256 = "f2bbe23e685852104fd48d0e34ac981b0917e76c62cfcd6d0ac5283e4710c7b9"
     source = "https://static.rust-lang.org/dist/rustc-1.69.0-src.tar.gz"
     source_sha256 = "b3cd9f481e1a2901bf6f3808d30c69cc4ea80d93c4cc4e2ed52258b180381205"
     stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
-    uri = "https://static.rust-lang.org/dist/rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz"
-    version = "1.71.1"
+    uri = "https://static.rust-lang.org/dist/rust-1.72.0-x86_64-unknown-linux-gnu.tar.gz"
+    version = "1.72.0"
 
     [[metadata.dependencies.licenses]]
       type = "Apache-2.0"


### PR DESCRIPTION
Reverts paketo-community/rust-dist#262

This isn't right. It shouldn't be going backwards, rather to 1.72.1.